### PR TITLE
refactor: update regex patterns to follow standard

### DIFF
--- a/45drives-disks/public/scripts/disk_info
+++ b/45drives-disks/public/scripts/disk_info
@@ -31,7 +31,7 @@ def getDiskInfo(path,server_info):
         c_lines = vdev_id.readlines()
     
     for line in c_lines:
-        regex = re.search("^alias\s+(\d+-\d+)\s+(\S+)",line)
+        regex = re.search(r"^alias\s+(\d+-\d+)\s+(\S+)",line)
         if regex != None:
             disks.append({"dev-by-path":regex.group(2),"bay-id":regex.group(1)})
         

--- a/45drives-disks/public/scripts/zfs_info
+++ b/45drives-disks/public/scripts/zfs_info
@@ -218,8 +218,8 @@ def zpool_status_parse(zp_status_obj, key, pool_name):
     disk_count = 0
     initial_disk = True
     for i in range(0,len(zp_status_default)):
-        re_vdev_default = re.search("^\t  (\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+).*",zp_status_default[i])
-        re_vdev_path = re.search("^\t  (/dev/\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+).*",zp_status_path[i])
+        re_vdev_default = re.search(r"^\t  (\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+).*",zp_status_default[i])
+        re_vdev_path = re.search(r"^\t  (/dev/\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+).*",zp_status_path[i])
         re_disk_path = re.search(f"^\t    (/dev/\S+)(?:-part[0-9])?\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+).*",zp_status_path[i])
         re_disk_default = re.search(f"^\t    (\S+)(?:-part[0-9])?\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+).*",zp_status_default[i])
         if re_vdev_default != None:

--- a/45drives-motherboard/public/helper_scripts/motherboard
+++ b/45drives-motherboard/public/helper_scripts/motherboard
@@ -167,7 +167,7 @@ def get_motherboard_model():
 		return False
 	for line in dmi_result:
 		for field in g_dmi_mobo_fields.keys():
-			regex = re.search("^\s({fld}):\s+(.*)".format(fld=field),line)
+			regex = re.search(r"^\s({fld}):\s+(.*)".format(fld=field),line)
 			if regex != None:
 				if g_dmi_mobo_fields[regex.group(1)] != None:
 					if regex.group(2) in g_dmi_mobo_fields[regex.group(1)]:
@@ -209,7 +209,7 @@ def get_cpu_info():
 		return False
 	for line in dmi_result:
 		for field in g_dmi_cpu_fields.keys():
-			regex = re.search("^\s({fld}):\s+(.*)".format(fld=field),line)
+			regex = re.search(r"^\s({fld}):\s+(.*)".format(fld=field),line)
 			if regex != None:
 				regex_group1_str = str(regex.group(1)).rstrip()
 				regex_group2_str = str(regex.group(2)).rstrip()
@@ -243,7 +243,7 @@ def get_sensor_readings():
 	sensor_readings = []
 	for line in ipmitool_sensor_result:
 		for field in g_ipmitool_sensor_fields.keys():
-			regex = re.search("^({fld})\s+\|\s+(\S+).*".format(fld=field),line)
+			regex = re.search(r"^({fld})\s+\|\s+(\S+).*".format(fld=field),line)
 			if regex != None:
 				# if regex.group(1) == "CPU Temp" or regex.group(1) == "CPU0_TEMP":
 				# 	# ipmitool does not use the socket name

--- a/45drives-motherboard/public/helper_scripts/network
+++ b/45drives-motherboard/public/helper_scripts/network
@@ -95,10 +95,10 @@ def get_network_info():
 	
 	network_json_str = "{\"Network Info\":["
 	for line in ipaddr_result:
-		regex_connection = re.search("^(\w)\S+\s+(\w+).*state\s(\w+).*",line)
-		regex_link = re.search("^\s+link/(\S+)\s(\S+).*",line)
-		regex_inet = re.search("^\s+inet\s(\S+).*$",line)
-		regex_inet6 = re.search("^\s+inet6\s(\S+).*$",line)
+		regex_connection = re.search(r"^(\w)\S+\s+(\w+).*state\s(\w+).*",line)
+		regex_link = re.search(r"^\s+link/(\S+)\s(\S+).*",line)
+		regex_inet = re.search(r"^\s+inet\s(\S+).*$",line)
+		regex_inet6 = re.search(r"^\s+inet6\s(\S+).*$",line)
 		if regex_connection != None:
 			network_json_str += (
 					"{\"Connection Name\":\"" + regex_connection.group(2)+"\"," +
@@ -127,7 +127,7 @@ def get_network_info():
 	
 	lshw = []
 	for line in lshw_result:
-		regex_lshw = re.search("^pci@(\S+)\s+(\S+)\s+(\S+)\s+(\S+)",line)
+		regex_lshw = re.search(r"^pci@(\S+)\s+(\S+)\s+(\S+)\s+(\S+)",line)
 		if regex_lshw != None:
 			lshw.append([regex_lshw.group(1),regex_lshw.group(2),regex_lshw.group(4)])
 			# print(f"device: {regex_lshw.group(2)}, bus: {regex_lshw.group(1)}, description: {regex_lshw.group(4)}")
@@ -141,7 +141,7 @@ def get_network_info():
 	slot_entries = []
 	for line in dmi_result:
 		for field in g_dmi_fields:
-			regex = re.search("^\s+({fld}):\s+(.*)".format(fld=field),line)
+			regex = re.search(r"^\s+({fld}):\s+(.*)".format(fld=field),line)
 			if regex != None:
 				slot_entries.append((regex.group(1),regex.group(2)))
 	cards = []

--- a/45drives-motherboard/public/helper_scripts/pci
+++ b/45drives-motherboard/public/helper_scripts/pci
@@ -498,14 +498,14 @@ def getNetworkCardModel(busAddress):
 
     for line in lspci_result:
         # print(f"Processing line from lspci: {line.strip()}")
-        regex_addr = re.search("^{addr}\\s(.*)$".format(addr=primary_bus_address), line)
+        regex_addr = re.search(r"^{addr}\\s(.*)$".format(addr=primary_bus_address), line)
         
         if regex_addr is not None:
             # print(f"Found matching address: {regex_addr.group(0)}")
             
             for model in g_network_card_models:
                 # print(f"Checking model: {model} against {regex_addr.group(1)}")
-                regex_model = re.search("{mdl}".format(mdl=model), regex_addr.group(1))
+                regex_model = re.search(r"{mdl}".format(mdl=model), regex_addr.group(1))
                 
                 if regex_model is not None:
                     # print(f"Matched model: {model}")
@@ -525,7 +525,7 @@ def sata():
 	sata_dict = {}
 	for line in lspci_result:
 		for field in g_sata_controllers:
-			regex = re.search("^(\S+).*({fld}).*$".format(fld=field),line)
+			regex = re.search(r"^(\S+).*({fld}).*$".format(fld=field),line)
 			if regex != None:
 				sata_dict["Card Type"] = "Serial ATA Controller"
 				sata_dict["Card Model"] = regex.group(2)
@@ -544,7 +544,7 @@ def sata():
 	for card in sata:
 		for line in ls_result:
 			drive_dict = {}
-			regex = re.search("pci-({ba})-ata-(\d)\s->\s\W+(.*)".format(ba=card["Bus Address"]),line)
+			regex = re.search(r"pci-({ba})-ata-(\d)\s->\s\W+(.*)".format(ba=card["Bus Address"]),line)
 			if regex != None:
 				drive_dict["Device"] = regex.group(3)
 				drive_dict["Path"] = "pci-" + regex.group(1) + "-ata-" + regex.group(2)
@@ -562,7 +562,7 @@ def lsblk(device):
 
 	partitions = []
 	for line in lsblk_result:
-		regex = re.search("^(\S+)\s+\S+\s+\S+\s+(\S+)\s+\S+\s+(\S+)(.*)$",line)
+		regex = re.search(r"^(\S+)\s+\S+\s+\S+\s+(\S+)\s+\S+\s+(\S+)(.*)$",line)
 		if regex != None and regex.group(1) != "NAME":
 			partitions.append(
 					{

--- a/45drives-motherboard/public/helper_scripts/sata
+++ b/45drives-motherboard/public/helper_scripts/sata
@@ -365,7 +365,7 @@ def lsblk(device):
 
 	partitions = []
 	for line in lsblk_result:
-		regex = re.search("^(\S+)\s+\S+\s+\S+\s+(\S+)\s+\S+\s+(\S+)(.*)$",line)
+		regex = re.search(r"^(\S+)\s+\S+\s+\S+\s+(\S+)\s+\S+\s+(\S+)(.*)$",line)
 		if regex != None and regex.group(1) != "NAME":
 			partitions.append(
 					{
@@ -387,7 +387,7 @@ def get_motherboard_model():
 		return False
 	for line in dmi_result:
 		for field in g_motherboard_sata_addresses.keys():
-			regex = re.search("^\sProduct Name:\s+({fld})".format(fld=field),line)
+			regex = re.search(r"^\sProduct Name:\s+({fld})".format(fld=field),line)
 			if regex != None:
 				mobo_model = field
 				break

--- a/45drives-system/public/scripts/cpu_info
+++ b/45drives-system/public/scripts/cpu_info
@@ -130,7 +130,7 @@ def get_cpu_info():
 		return False
 	for line in dmi_result:
 		for field in g_dmi_cpu_fields.keys():
-			regex = re.search("^\s({fld}):\s+(.*)".format(fld=field),line)
+			regex = re.search(r"^\s({fld}):\s+(.*)".format(fld=field),line)
 			if regex != None:
 				regex_group1_str = str(regex.group(1)).rstrip()
 				regex_group2_str = str(regex.group(2)).rstrip()
@@ -163,7 +163,7 @@ def get_sensor_readings():
 	sensor_readings = []
 	for line in ipmitool_sensor_result:
 		for field in g_ipmitool_sensor_fields.keys():
-			regex = re.search("^({fld})\s+\|\s+(\S+).*".format(fld=field), line)
+			regex = re.search(r"^({fld})\s+\|\s+(\S+).*".format(fld=field), line)
 			if regex != None:
 				# if regex.group(1) == "CPU Temp" or regex.group(1) == "CPU0_TEMP":
 				#     # ipmitool does not use the socket name

--- a/45drives-system/public/scripts/ipmi
+++ b/45drives-system/public/scripts/ipmi
@@ -35,7 +35,7 @@ def ipmi_lan():
 
 	for line in ipmi_lan_result:
 		for field in ipmi_lan_dict.keys():
-			regex = re.search("^({fld})\s+:\s+(\S+)".format(fld=field),line)
+			regex = re.search(r"^({fld})\s+:\s+(\S+)".format(fld=field),line)
 			if regex != None:
 				ipmi_lan_dict[regex.group(1)] = regex.group(2)
 	return ipmi_lan_dict

--- a/45drives-system/public/scripts/motherboard
+++ b/45drives-system/public/scripts/motherboard
@@ -167,7 +167,7 @@ def get_motherboard_model():
 		return False
 	for line in dmi_result:
 		for field in g_dmi_mobo_fields.keys():
-			regex = re.search("^\s({fld}):\s+(.*)".format(fld=field),line)
+			regex = re.search(r"^\s({fld}):\s+(.*)".format(fld=field),line)
 			if regex != None:
 				if g_dmi_mobo_fields[regex.group(1)] != None:
 					if regex.group(2) in g_dmi_mobo_fields[regex.group(1)]:
@@ -209,7 +209,7 @@ def get_cpu_info():
 		return False
 	for line in dmi_result:
 		for field in g_dmi_cpu_fields.keys():
-			regex = re.search("^\s({fld}):\s+(.*)".format(fld=field),line)
+			regex = re.search(r"^\s({fld}):\s+(.*)".format(fld=field),line)
 			if regex != None:
 				regex_group1_str = str(regex.group(1)).rstrip()
 				regex_group2_str = str(regex.group(2)).rstrip()
@@ -243,7 +243,7 @@ def get_sensor_readings():
 	sensor_readings = []
 	for line in ipmitool_sensor_result:
 		for field in g_ipmitool_sensor_fields.keys():
-			regex = re.search("^({fld})\s+\|\s+(\S+).*".format(fld=field),line)
+			regex = re.search(r"^({fld})\s+\|\s+(\S+).*".format(fld=field),line)
 			if regex != None:
 				# if regex.group(1) == "CPU Temp" or regex.group(1) == "CPU0_TEMP":
 				# 	# ipmitool does not use the socket name

--- a/45drives-system/public/scripts/network
+++ b/45drives-system/public/scripts/network
@@ -154,7 +154,7 @@ def get_network_info():
 		return False
 	lshw = []
 	for line in lshw_result:
-		regex_lshw = re.search("^pci@(\S+)\s+(\S+)\s+(\S+)\s+(\S+)",line)
+		regex_lshw = re.search(r"^pci@(\S+)\s+(\S+)\s+(\S+)\s+(\S+)",line)
 		if regex_lshw != None:
 			lshw.append([regex_lshw.group(1),regex_lshw.group(2),regex_lshw.group(4)])
 
@@ -184,7 +184,7 @@ def get_network_info():
 	slot_entries = []
 	for line in dmi_result:
 		for field in g_dmi_fields:
-			regex = re.search("^\s+({fld}):\s+(.*)".format(fld=field),line)
+			regex = re.search(r"^\s+({fld}):\s+(.*)".format(fld=field),line)
 			if regex != None:
 				slot_entries.append((regex.group(1),regex.group(2)))
 

--- a/45drives-system/public/scripts/sata
+++ b/45drives-system/public/scripts/sata
@@ -364,7 +364,7 @@ def lsblk(device):
 
 	partitions = []
 	for line in lsblk_result:
-		regex = re.search("^(\S+)\s+\S+\s+\S+\s+(\S+)\s+\S+\s+(\S+)(.*)$",line)
+		regex = re.search(r"^(\S+)\s+\S+\s+\S+\s+(\S+)\s+\S+\s+(\S+)(.*)$",line)
 		if regex != None and regex.group(1) != "NAME":
 			partitions.append(
 					{
@@ -386,7 +386,7 @@ def get_motherboard_model():
 		return False
 	for line in dmi_result:
 		for field in g_motherboard_sata_addresses.keys():
-			regex = re.search("^\sProduct Name:\s+({fld})".format(fld=field),line)
+			regex = re.search(r"^\sProduct Name:\s+({fld})".format(fld=field),line)
 			if regex != None:
 				mobo_model = field
 				break


### PR DESCRIPTION
# Summary
Fix for #38 
Updated `re.search("` to `re.search(r"` where appropriate to follow standards.

# Reasoning
Older versions of python would allow invalid regex patterns and fail silently.
Python 3.11+ rejects some of these regex patterns and shows a warning

For example this is the result from the network script:
```
/usr/share/cockpit/45drives-motherboard/helper_scripts/network:98: SyntaxWarning: invalid escape sequence '\w'
  regex_connection = re.search("^(\w)\S+\s+(\w+).*state\s(\w+).*",line)
/usr/share/cockpit/45drives-motherboard/helper_scripts/network:99: SyntaxWarning: invalid escape sequence '\s'
  regex_link = re.search("^\s+link/(\S+)\s(\S+).*",line)
/usr/share/cockpit/45drives-motherboard/helper_scripts/network:100: SyntaxWarning: invalid escape sequence '\s'
  regex_inet = re.search("^\s+inet\s(\S+).*$",line)
/usr/share/cockpit/45drives-motherboard/helper_scripts/network:101: SyntaxWarning: invalid escape sequence '\s'
  regex_inet6 = re.search("^\s+inet6\s(\S+).*$",line)
/usr/share/cockpit/45drives-motherboard/helper_scripts/network:130: SyntaxWarning: invalid escape sequence '\S'
  regex_lshw = re.search("^pci@(\S+)\s+(\S+)\s+(\S+)\s+(\S+)",line)
/usr/share/cockpit/45drives-motherboard/helper_scripts/network:144: SyntaxWarning: invalid escape sequence '\s'
  regex = re.search("^\s+({fld}):\s+(.*)".format(fld=field),line)
{
    "PCI Info": [
    ...
```


## Note
While I've included this fix for the `45drives-disk`, it does not fix the script as it relies on the `/opt/45drives/tools/dmap` and `/opt/45drives/tools/server_identifier` in another repo and require updates to those.

This change is fully backwards compatible and was already completed in other parts of the code.