### PR TITLE
added f8x3-u2 and -edfss unit and fixed asrock GENOAD8X-2T/BCM mappings

### DIFF
--- a/45drives-disks/src/App.vue
+++ b/45drives-disks/src/App.vue
@@ -156,6 +156,24 @@ export default {
             case "NVME-F8X3":
               pageLayout.value = "B";
               break;
+            case "NVME-F8X1-U2":
+              pageLayout.value = "B";
+              break;
+            case "NVME-F8X2-U2":
+              pageLayout.value = "B";
+              break;
+            case "NVME-F8X3-U2":
+              pageLayout.value = "B";
+              break;
+            case "NVME-F8X1-EDSFF":
+              pageLayout.value = "B";
+              break;
+            case "NVME-F8X2-EDSFF":
+              pageLayout.value = "B";
+              break;
+            case "NVME-F8X3-EDSFF":
+              pageLayout.value = "B";
+              break;  
             case "E16":
               pageLayout.value = "A";
               break;
@@ -251,6 +269,24 @@ export default {
               pageLayout.value = "BZ";
               break;
             case "NVME-F8X3":
+              pageLayout.value = "BZ";
+              break;
+            case "NVME-F8X1-U2":
+              pageLayout.value = "BZ";
+              break;
+            case "NVME-F8X2-U2":
+              pageLayout.value = "BZ";
+              break;
+            case "NVME-F8X3-U2":
+              pageLayout.value = "BZ";
+              break;
+            case "NVME-F8X1-EDSFF":
+              pageLayout.value = "BZ";
+              break;
+            case "NVME-F8X2-EDSFF":   
+              pageLayout.value = "BZ";
+              break;
+            case "NVME-F8X3-EDSFF":
               pageLayout.value = "BZ";
               break;
             case "E16":

--- a/45drives-disks/src/components/CanvasSection.vue
+++ b/45drives-disks/src/components/CanvasSection.vue
@@ -161,7 +161,7 @@ export default {
 
     const enableSketch = (modelString) => {
       let testString =
-        /(Storinator|Stornado|HomeLab|Professional|Proxinator|Studio)-(H8)?(H16|H32)?-?(HL15_BEAST|HL15|HL4|HL8|X15|PRO15|PRO4|PRO8|AV15|Q30|S45|XL60|F2|2U|MI4|C8|F8X1|F8X2|F8X3|NVME-F8X1|NVME-F8X2|NVME-F8X3|E16|VM8|VM16|VM32|STUDIO8|F16|VM2)/m.exec(
+        /(Storinator|Stornado|HomeLab|Professional|Proxinator|Studio)-(H8)?(H16|H32)?-?(HL15_BEAST|HL15|HL4|HL8|X15|PRO15|PRO4|PRO8|AV15|Q30|S45|XL60|F2|2U|MI4|C8|NVME-F8X1-U2|NVME-F8X1-EDSFF|NVME-F8X2-U2|NVME-F8X2-EDSFF|NVME-F8X3-U2|NVME-F8X3-EDSFF|NVME-F8X1|NVME-F8X2|NVME-F8X3|F8X1|F8X2|F8X3|E16|VM8|VM16|VM32|STUDIO8|F16|VM2)/m.exec(
           modelString
         );
       let enableString = testString
@@ -169,7 +169,7 @@ export default {
         : "";
 
       if (enableString.includes('NVME-')) {
-        enableString = enableString.replace('NVME-', '') + 'NVME';
+        enableString = enableString.replace(/NVME-([^-]+)(?:-U2|-EDSFF)?/, '$1NVME');
       }
 
       // HomeLab-X15 uses the same chassis as HL15

--- a/45drives-fan-controller/src/App.vue
+++ b/45drives-fan-controller/src/App.vue
@@ -34,7 +34,7 @@ async function checkChassisSize() {
     });
     const info = JSON.parse(raw);
     chassisSize.value = info["Chassis Size"] || "Unknown";
-    chassisSupported.value = ["NVME-F8X1", "NVME-F8X2", "NVME-F8X3"].includes(chassisSize.value);
+    chassisSupported.value = ["NVME-F8X1", "NVME-F8X2", "NVME-F8X3", "NVME-F8X1-U2", "NVME-F8X2-U2", "NVME-F8X3-U2", "NVME-F8X1-EDSFF", "NVME-F8X2-EDSFF", "NVME-F8X3-EDSFF"].includes(chassisSize.value);
   } catch (err) {
     console.error("Failed to read server info for chassis check:", err);
     chassisSize.value = "Unknown";

--- a/45drives-motherboard/public/helper_scripts/pci
+++ b/45drives-motherboard/public/helper_scripts/pci
@@ -387,12 +387,34 @@ def fix_slot_type(slot, motherboard_model):
             return
 
     slot_type = str(slot.get("Type", "")).strip()
-    if slot_type not in ("", "-", "Unknown", "<OUT OF SPEC>"):
+    if slot_type not in ("", "-", "Unknown", "<OUT OF SPEC>") and "<OUT OF SPEC>" not in slot_type:
         return
 
-    inferred = infer_pcie_type_from_sysfs(slot.get("Bus Address", ""))
+    bus_address = slot.get("Bus Address", "")
+    inferred = infer_pcie_type_from_sysfs(bus_address)
+
+    # If direct sysfs read failed, try reading the first downstream device
+    if not inferred and bus_address:
+        dev_path = f"/sys/bus/pci/devices/{bus_address}"
+        if os.path.isdir(dev_path):
+            for entry in sorted(os.listdir(dev_path)):
+                if _PCI_ADDR_RE.match(entry):
+                    inferred = infer_pcie_type_from_sysfs(entry)
+                    if inferred:
+                        break
+
+    # Last resort: strip <OUT OF SPEC> and keep just the width
+    if not inferred and "<OUT OF SPEC>" in slot_type:
+        width_match = re.search(r"x(\d+)", slot_type)
+        if width_match:
+            inferred = f"PCI Express x{width_match.group(1)}"
+
     if inferred:
-        slot["Type"] = inferred
+        # Preserve M.2 Slot wrapper for M2_ designations
+        if designation.startswith("M2_"):
+            slot["Type"] = f"M.2 Slot ({inferred})"
+        else:
+            slot["Type"] = inferred
         slot["PCI Type"] = inferred
 
 
@@ -662,6 +684,16 @@ def process_pci_slots_and_devices(
     motherboard_model = motherboard_info["Motherboard"][0].get("Product Name", "")
     mw34_claimed = set()
 
+    # For GENOA boards: collect all dmidecode bus addresses to avoid
+    # sibling scanning from claiming another slot's direct address.
+    genoa_dmi_buses = set()
+    genoa_claimed = set()  # track resolved endpoints to prevent double-claim
+    if motherboard_model.startswith(("GENOAD8X", "GENOAD8UD")):
+        for s in pci_slots:
+            ba = s.get("Bus Address", "")
+            if ba and ba != "0000:00:00.0":
+                genoa_dmi_buses.add(ba)
+
     for slot in pci_slots:
         designation = slot.get("Designation", "")
         slot_type = slot.get("Type", "")
@@ -716,6 +748,39 @@ def process_pci_slots_and_devices(
                     if cand not in mw34_claimed and cand in lspci_devices:
                         slot["Bus Address"] = cand
                         break
+
+        # ---------- ASRock GENOA special handling ----------
+        # dmidecode bus addresses point to one root port function (e.g. c0:03.1)
+        # but cards may be on sibling functions (e.g. c0:03.3). Scan all siblings.
+        # Exclude siblings that are another slot's direct dmidecode bus address.
+        if motherboard_model.startswith(("GENOAD8X", "GENOAD8UD")):
+            bus = slot.get("Bus Address", "")
+            found = False
+            if bus and bus != "0000:00:00.0":
+                candidates = [bus]
+                m = re.match(r'^(0000:[0-9a-fA-F]{2}:[0-9a-fA-F]{2})\.[0-9a-fA-F]$', bus)
+                if m:
+                    prefix = m.group(1)
+                    for fn in range(8):
+                        sibling = f"{prefix}.{fn}"
+                        if sibling != bus and sibling in lspci_devices \
+                                and sibling not in genoa_dmi_buses:
+                            candidates.append(sibling)
+                for cand in candidates:
+                    if slot_has_pci_device(cand, lspci_devices):
+                        endpoint = first_endpoint_addr(cand, lspci_devices)
+                        resolved = endpoint or cand
+                        if resolved in genoa_claimed:
+                            continue  # already claimed by another slot
+                        slot["Bus Address"] = resolved
+                        slot["Current Usage"] = "In Use"
+                        genoa_claimed.add(resolved)
+                        found = True
+                        break
+            if not found:
+                slot["Current Usage"] = "Available"
+            matched_devices.setdefault(designation, slot)
+            continue
 
         if designation not in matched_devices:
             matched_devices[designation] = slot
@@ -993,6 +1058,49 @@ def main():
                     break
             # Fallback: detect network card from lspci_devices (like MZ73)
             if not net_matched and slot.get("Card Type", "-") == "-":
+                devinfo = lspci_devices.get(bus)
+                if devinfo and "ethernet" in str(devinfo[0]).strip('"').lower():
+                    slot["Card Type"] = "Network Card"
+                    model = getNetworkCardModel(bus)
+                    if model not in ("-", "unknown"):
+                        slot["Card Model"] = model
+                    elif len(devinfo) > 2:
+                        slot["Card Model"] = devinfo[2].strip('"')
+            for card in sata_cards:
+                if card.get("Bus Address") == bus:
+                    slot["Card Type"] = card["Card Type"]
+                    slot["Card Model"] = card["Card Model"]
+                    slot["Connections"] = card.get("Connections", [])
+                    break
+
+    # ASRock GENOA: bus addresses from dmidecode are bridges, so re-match after
+    # process_pci_slots_and_devices() has resolved to endpoint addresses.
+    if motherboard_model.startswith(("GENOAD8X", "GENOAD8UD")):
+        for slot in matched_devices:
+            bus = slot.get("Bus Address", "")
+            if not bus or bus == "0000:00:00.0":
+                continue
+            existing_card_type = slot.get("Card Type", "-")
+            # Refresh NIC model with resolved endpoint bus address
+            if existing_card_type == "Network Card":
+                slot["Card Model"] = getNetworkCardModel(bus)
+                continue
+            if existing_card_type not in ("", "-"):
+                continue  # HBA/SATA already identified, no refresh needed
+            for hba in hba_cards:
+                if hba["Bus Address"] == bus:
+                    slot["Card Type"] = "HBA"
+                    slot["Card Model"] = hba["Model"]
+                    break
+            net_matched = False
+            for card in network_cards:
+                if card.get("Bus Address") == bus:
+                    slot["Card Type"] = "Network Card"
+                    slot["Card Model"] = getNetworkCardModel(bus)
+                    slot.setdefault("Connections", []).append(card)
+                    net_matched = True
+                    break
+            if not net_matched and slot.get("Card Type", "-") in ("", "-"):
                 devinfo = lspci_devices.get(bus)
                 if devinfo and "ethernet" in str(devinfo[0]).strip('"').lower():
                     slot["Card Type"] = "Network Card"

--- a/45drives-system/public/scripts/pci
+++ b/45drives-system/public/scripts/pci
@@ -400,12 +400,53 @@ def fix_slot_type(slot, motherboard_model):
             return
 
     slot_type = str(slot.get("Type", "")).strip()
-    if slot_type not in ("", "-", "Unknown", "<OUT OF SPEC>"):
+    if slot_type not in ("", "-", "Unknown", "<OUT OF SPEC>") and "<OUT OF SPEC>" not in slot_type:
         return
 
-    inferred = infer_pcie_type_from_sysfs(slot.get("Bus Address", ""))
+    bus_address = slot.get("Bus Address", "")
+    inferred = infer_pcie_type_from_sysfs(bus_address)
+
+    # If direct sysfs read failed, try reading the first downstream device
+    if not inferred and bus_address:
+        dev_path = f"/sys/bus/pci/devices/{bus_address}"
+        if os.path.isdir(dev_path):
+            for entry in sorted(os.listdir(dev_path)):
+                if _PCI_ADDR_RE.match(entry):
+                    inferred = infer_pcie_type_from_sysfs(entry)
+                    if inferred:
+                        break
+
+    # Fallback: extract width from the original type string and guess gen from sysfs current_link_speed
+    if not inferred and "<OUT OF SPEC>" in slot_type:
+        width_match = re.search(r"x(\d+)", slot_type)
+        if width_match and bus_address:
+            speed_path = f"/sys/bus/pci/devices/{bus_address}/current_link_speed"
+            max_speed_path = f"/sys/bus/pci/devices/{bus_address}/max_link_speed"
+            for sp in (max_speed_path, speed_path):
+                try:
+                    with open(sp, "r") as f:
+                        speed_raw = f.read().strip()
+                    speed_match = re.search(r"([0-9]+(?:\.[0-9]+)?)", speed_raw)
+                    if speed_match:
+                        gen = _pcie_gen_from_speed(speed_match.group(1))
+                        if gen:
+                            inferred = f"PCI Express {gen} x{width_match.group(1)}"
+                            break
+                except Exception:
+                    continue
+
+    # Last resort: strip <OUT OF SPEC> and format cleanly with just the width
+    if not inferred and "<OUT OF SPEC>" in slot_type:
+        width_match = re.search(r"x(\d+)", slot_type)
+        if width_match:
+            inferred = f"PCI Express x{width_match.group(1)}"
+
     if inferred:
-        slot["Type"] = inferred
+        # Preserve M.2 Slot wrapper for M2_ designations
+        if designation.startswith("M2_"):
+            slot["Type"] = f"M.2 Slot ({inferred})"
+        else:
+            slot["Type"] = inferred
         slot["PCI Type"] = inferred
 
 
@@ -712,6 +753,16 @@ def process_pci_slots_and_devices(pci_slots, devices, lspci_devices):
     matched_devices = {}
     mw34_claimed = set()
 
+    # For GENOA boards: collect all dmidecode bus addresses to avoid
+    # sibling scanning from claiming another slot's direct address.
+    genoa_dmi_buses = set()
+    genoa_claimed = set()  # track resolved endpoints to prevent double-claim
+    if motherboard_model.startswith(("GENOAD8X", "GENOAD8UD")):
+        for s in pci_slots:
+            ba = s.get("Bus Address", "")
+            if ba and ba != "0000:00:00.0":
+                genoa_dmi_buses.add(ba)
+
     for slot in pci_slots:
         designation = slot.get("Designation", "")
         slot_type = slot.get("Type", "")
@@ -780,6 +831,40 @@ def process_pci_slots_and_devices(pci_slots, devices, lspci_devices):
                     if cand not in mw34_claimed and cand in lspci_devices:
                         slot["Bus Address"] = cand
                         break
+
+        # ---------- ASRock GENOA special handling ----------
+        # dmidecode bus addresses point to one root port function (e.g. c0:03.1)
+        # but cards may be on sibling functions (e.g. c0:03.3). Scan all siblings.
+        # Exclude siblings that are another slot's direct dmidecode bus address.
+        if motherboard_model.startswith(("GENOAD8X", "GENOAD8UD")):
+            bus = slot.get("Bus Address", "")
+            found = False
+            if bus and bus != "0000:00:00.0":
+                # Build list of candidate addresses: the original + unclaimed sibling functions
+                candidates = [bus]
+                m = re.match(r'^(0000:[0-9a-fA-F]{2}:[0-9a-fA-F]{2})\.[0-9a-fA-F]$', bus)
+                if m:
+                    prefix = m.group(1)
+                    for fn in range(8):
+                        sibling = f"{prefix}.{fn}"
+                        if sibling != bus and sibling in lspci_devices \
+                                and sibling not in genoa_dmi_buses:
+                            candidates.append(sibling)
+                for cand in candidates:
+                    if slot_has_pci_device(cand, lspci_devices):
+                        endpoint = first_endpoint_addr(cand, lspci_devices)
+                        resolved = endpoint or cand
+                        if resolved in genoa_claimed:
+                            continue  # already claimed by another slot
+                        slot["Bus Address"] = resolved
+                        slot["Current Usage"] = "In Use"
+                        genoa_claimed.add(resolved)
+                        found = True
+                        break
+            if not found:
+                slot["Current Usage"] = "Available"
+            matched_devices.setdefault(designation, slot)
+            continue
 
         # ---------- Generic boards ----------
         if designation not in matched_devices:
@@ -1370,6 +1455,49 @@ def main():
                     slot["Card Model"] = model
                 elif len(devinfo) > 2:
                     slot["Card Model"] = devinfo[2].strip('"')
+
+    # ASRock GENOA: bus addresses from dmidecode are bridges, so re-match after
+    # process_pci_slots_and_devices() has resolved to endpoint addresses.
+    if motherboard_model.startswith(("GENOAD8X", "GENOAD8UD")):
+        for slot in matched:
+            bus = slot.get("Bus Address", "")
+            if not bus or bus == "0000:00:00.0":
+                continue
+            existing_card_type = slot.get("Card Type", "-")
+            # Refresh NIC model with resolved endpoint bus address
+            if existing_card_type == "Network Card":
+                slot["Card Model"] = getNetworkCardModel(bus)
+                continue
+            if existing_card_type not in ("", "-"):
+                continue  # HBA/SATA already identified, no refresh needed
+            for hba in hba_cards:
+                if hba["Bus Address"] == bus:
+                    slot["Card Type"] = "HBA"
+                    slot["Card Model"] = hba["Model"]
+                    break
+            net_matched = False
+            for card in network_cards:
+                if card.get("Bus Address") == bus:
+                    slot["Card Type"] = "Network Card"
+                    slot["Card Model"] = getNetworkCardModel(bus)
+                    slot.setdefault("Connections", []).append(card)
+                    net_matched = True
+                    break
+            if not net_matched and slot.get("Card Type", "-") in ("", "-"):
+                devinfo = lspci_devices.get(bus)
+                if devinfo and "ethernet" in str(devinfo[0]).strip('"').lower():
+                    slot["Card Type"] = "Network Card"
+                    model = getNetworkCardModel(bus)
+                    if model not in ("-", "unknown"):
+                        slot["Card Model"] = model
+                    elif len(devinfo) > 2:
+                        slot["Card Model"] = devinfo[2].strip('"')
+            for card in sata_cards:
+                if card.get("Bus Address") == bus:
+                    slot["Card Type"] = card["Card Type"]
+                    slot["Card Model"] = card["Card Model"]
+                    slot["Connections"] = card["Connections"]
+                    break
 
     # Final type cleanup for bad firmware strings (e.g. <OUT OF SPEC>)
     for slot in matched:

--- a/45drives-system/public/scripts/server_info
+++ b/45drives-system/public/scripts/server_info
@@ -12,8 +12,8 @@ def main():
 		server_info = {
 			"error_msg": "/etc/45drives/server_info/server_info.json does not exist"
 		}
-		print(json.dumps(server_info,indent=4),file=sys.stderr)
-		sys.exit(1)
+		print(json.dumps(server_info,indent=4))
+		sys.exit(0)
 
 if __name__ == "__main__":
     main()

--- a/45drives-system/src/App.vue
+++ b/45drives-system/src/App.vue
@@ -3,6 +3,7 @@ import "@fontsource/red-hat-text/600.css";
 import "@fontsource/red-hat-text/400.css";
 import FfdHeader from "./components/FfdHeader.vue";
 import SectionContainer from "./components/SectionContainer.vue";
+import { NotificationView } from "@45drives/houston-common-ui";
 import { ref , onMounted, provide} from "vue";
 
 const adminCheck = ref(false);
@@ -120,6 +121,7 @@ onMounted(()=>{
 <template>
   <div class="h-full flex flex-col overflow-hidden">
     <FfdHeader moduleName="System" centerName />
+    <NotificationView />
     <SectionContainer v-if="adminCheck && adminFlag" />
     <div
       v-else-if="adminCheck && !adminFlag"

--- a/45drives-system/src/components/SectionSystem.vue
+++ b/45drives-system/src/components/SectionSystem.vue
@@ -103,6 +103,7 @@ import { RefreshIcon as RefreshIconOutline } from "@heroicons/vue/outline";
 import { ref } from "vue";
 import ErrorMessage from "./ErrorMessage.vue";
 import { server, Command, unwrap } from "@45drives/houston-common-lib";
+import { pushNotification, Notification } from "@45drives/houston-common-ui";
 
 export default {
   components: {
@@ -209,6 +210,34 @@ export default {
           new Command(["/usr/share/cockpit/45drives-system/scripts/server_info"], { superuser: "require" })
         ));
         let sysInfo = JSON.parse(proc.getStdout());
+        if (sysInfo["error_msg"]) {
+          const missingNotification = new Notification(
+            "Server Info Missing",
+            sysInfo["error_msg"],
+            "error",
+            "never",
+            "server-info-missing"
+          ).addAction("Fix now", async () => {
+            try {
+              await unwrap(server.execute(
+                new Command(["/opt/45drives/tools/server_identifier"], { superuser: "require" })
+              ));
+              missingNotification.remove();
+              await getSystemInfo();
+            } catch (error) {
+              pushNotification(
+                new Notification(
+                  "Fix Failed",
+                  `server_identifier failed: ${error.message || error}`,
+                  "error",
+                  10_000
+                )
+              );
+            }
+          }, false);
+          pushNotification(missingNotification);
+          return;
+        }
         sysModel.value = sysInfo["Model"];
         sysChassis.value = sysInfo["Chassis Size"];
         sysSerial.value = sysInfo["Serial"];
@@ -220,47 +249,11 @@ export default {
         serverImgPath.value = getSystemImgPath(sysInfo["Model"]);
       } catch (err) {
         console.log(err);
-        try {
-          console.log(err.stdout);
-          let errorJson = JSON.parse(err.stdout);
-          fatalErrorMsg.value.length = 0;
-          fatalErrorMsg.value.push(errorJson["error_msg"]);
-          fatalErrorMsg.value.push("Click \"Fix\" to run /opt/45drives/tools/server_identifier");
-          fatalError.value = true;
-          if (
-            errorJson["error_msg"] ==
-            "/etc/45drives/server_info/server_info.json does not exist"
-          ) {
-            showFixButton.value = true;
-            fixButtonHandler.value = async () => {
-              try {
-                const fixState = await unwrap(server.execute(
-                  new Command(["/opt/45drives/tools/server_identifier"], { superuser: "require" })
-                ));
-                fatalError.value = false;
-                fatalErrorMsg.value.length = 0;
-                showFixButton.value = false;
-                getSystemInfo();
-              } catch (error) {
-                console.log(error);
-                fatalError.value = true;
-                fatalErrorMsg.value.length = 0;
-                if (error.message) fatalErrorMsg.value.push(error.message);
-                fatalErrorMsg.value.push("An error occurred when running /opt/45drives/tools/server_identifier");
-                showFixButton.value = false;
-              }
-            };
-          }else{
-
-          }
-        } catch (error) {
-          console.log(error);
-          fatalError.value = true;
-          fatalErrorMsg.value.length = 0;
-          if (error.message) fatalErrorMsg.value.push(error.message);
-          fatalErrorMsg.value.push("An error occurred when trying to run /usr/share/cockpit/45drives-system/scripts/server_info");
-          showFixButton.value = false;
-        }
+        fatalError.value = true;
+        fatalErrorMsg.value.length = 0;
+        if (err.message) fatalErrorMsg.value.push(err.message);
+        fatalErrorMsg.value.push("An error occurred when trying to run /usr/share/cockpit/45drives-system/scripts/server_info");
+        showFixButton.value = false;
       }
     };
 

--- a/45drives-system/src/components/SectionSystem.vue
+++ b/45drives-system/src/components/SectionSystem.vue
@@ -135,7 +135,7 @@ export default {
       }
       console.log('[Debug]: MODEL ->', model)
       const regExpModel =
-        /(Storinator|Stornado|HomeLab|Professional|Proxinator|Studio|Gateway).*(HL15_BEAST|HL15|HL4|HL8|X15|PRO4|PRO8|PRO15|AV15|Q30|S45|XL60|C8|MI4|NVME-F8X1|NVME-F8X2|NVME-F8X3|F8X1|F8X2|F8X3|F2|VM2|VM4|VM8|VM16|VM32|STUDIO8|STUDIO15|F16|2UGW_REV2|1UGW|2U).*/;
+        /(Storinator|Stornado|HomeLab|Professional|Proxinator|Studio|Gateway).*?(NVME-F8X1-U2|NVME-F8X1-EDSFF|NVME-F8X2-U2|NVME-F8X2-EDSFF|NVME-F8X3-U2|NVME-F8X3-EDSFF|NVME-F8X1|NVME-F8X2|NVME-F8X3|HL15_BEAST|HL15|HL4|HL8|X15|PRO4|PRO8|PRO15|AV15|Q30|S45|XL60|C8|MI4|F8X1|F8X2|F8X3|F2|VM2|VM4|VM8|VM16|VM32|STUDIO8|STUDIO15|F16|2UGW_REV2|1UGW|2U).*/;
       const match = model.match(regExpModel);
       const imgPathLookup = {
         "Storinator": {
@@ -149,8 +149,14 @@ export default {
           "F8X2": "img/F8X2.png",
           "F8X3": "img/F8X3.png",
           "NVME-F8X1": "img/45dlogo.png",
+          "NVME-F8X1-U2": "img/45dlogo.png",
+          "NVME-F8X1-EDSFF": "img/45dlogo.png",
           "NVME-F8X2": "img/45dlogo.png",
-          "NVME-F8X3": "img/45dlogo.png"
+          "NVME-F8X2-U2": "img/45dlogo.png",
+          "NVME-F8X2-EDSFF": "img/45dlogo.png",
+          "NVME-F8X3": "img/45dlogo.png",
+          "NVME-F8X3-U2": "img/45dlogo.png",
+          "NVME-F8X3-EDSFF": "img/45dlogo.png"
         },
         "Stornado": {
           "2U": "img/stornado2U.png",


### PR DESCRIPTION
**Title:** Add NVME-F8X U2/EDSFF variants, fix GENOAD8X PCI detection & System tab missing server_info crash



**Description:**

NVME-F8X U2/EDSFF support:

- Add NVME-F8X{1,2,3}-U2 and NVME-F8X{1,2,3}-EDSFF chassis variants to disk viewer and system image components
- Fix regex ordering to prevent shorter patterns from matching before longer NVME variants

 **GENOAD8X PCI slot detection fix:**

- Fix PCI slot detection on ASRock GENOAD8X-2T/BCM boards (slots incorrectly showing "Available")
- Scan sibling root-port functions (dmidecode reports wrong function numbers)
- Prevent slots from stealing each other's endpoints
- Re-run HBA/NIC/SATA matching after address resolution
- Handle slot types via sysfs fallback

**System tab server_info notification:**

- Fixed "Fix now" button notification  to run server_identifier when server_info.json is missing

